### PR TITLE
cron-parser v5 fixup

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const cronParser = require('cron-parser')
+const { CronExpressionParser: cronParser } = require('cron-parser')
 const { computeBackoff } = require('./backoff')
 const { request } = require('undici')
 
@@ -113,7 +113,7 @@ class Executor {
         // let's schedule the next call if it's a cron
         if (message.cronId) {
           const [cron] = await app.platformatic.entities.cron.find({ where: { id: { eq: message.cronId } }, tx })
-          const interval = cronParser.parseExpression(cron.schedule)
+          const interval = cronParser.parse(cron.schedule)
           const next = interval.next()
           await app.platformatic.entities.message.save({
             input: {

--- a/test/cron.test.js
+++ b/test/cron.test.js
@@ -6,8 +6,8 @@ const { once, EventEmitter } = require('events')
 const tspl = require('@matteo.collina/tspl')
 const Fastify = require('fastify')
 
-test('happy path', async (t) => {
-  const plan = tspl(t, { plan: 6 })
+test('happy path', { only: true }, async (t) => {
+  const plan = tspl(t, { plan: 9 })
   const ee = new EventEmitter()
   const server = await buildServer(t)
 
@@ -106,6 +106,12 @@ test('happy path', async (t) => {
 
   const p2 = once(ee, 'called')
   await p2
+  const messages = await server.platformatic.entities.message.find()
+  plan.equal(messages.length, 2)
+  const sentMessage = messages.filter((m) => m.sentAt !== null)[0]
+  const unsentMessage = messages.filter((m) => m.sentAt === null)[0]
+  plan.strictEqual(sentMessage.queueId, Number(queueId))
+  plan.strictEqual(unsentMessage.queueId, Number(queueId))
 })
 
 test('invalid cron expression', async (t) => {


### PR DESCRIPTION
Forgot to change cron-parser `parse for v5. 
Fixed and added the test that was missing (basically the transaction was rolling back whan rescheduling the message and this wasn't detected by the test). 